### PR TITLE
The correction checks if ele_name has a value before wrapping it with…

### DIFF
--- a/milestone1/design-blocks/custom_blocks.js
+++ b/milestone1/design-blocks/custom_blocks.js
@@ -84,13 +84,11 @@ Blockly.JavaScript['element_symbol'] = function(block) {
 Blockly.JavaScript['element_coefficient'] = function(block) {
 	var num = block.getFieldValue('NUMBER');
 	var ele_name = Blockly.JavaScript.valueToCode(block, 'COEFFICIENT', Blockly.JavaScript.ORDER_NONE);
-	if (ele_name) {
-		ele_name = '(' + ele_name + ')';
-	}
-	var code = num + ele_name;
-  	return [code, Blockly.JavaScript.ORDER_NONE];
-};
-
+	// Check if ele_name has a value before adding parentheses
+	var code = ele_name ? num + '(' + ele_name + ')' : num;
+	return [code, Blockly.JavaScript.ORDER_NONE];
+  };
+  
 Blockly.JavaScript['compound'] = function(block) {
 	var element1 = Blockly.JavaScript.valueToCode(block, 'ELEMENT1', Blockly.JavaScript.ORDER_NONE);
 	var element2 = Blockly.JavaScript.valueToCode(block, 'ELEMENT2', Blockly.JavaScript.ORDER_NONE);


### PR DESCRIPTION
… parentheses. If ele_name is empty (which means no element or compound block is attached), it will return just the number, avoiding a syntax like 2(). This ensures that the output code is syntactically correct and semantically meaningful, representing a valid coefficient in a chemical equation.